### PR TITLE
Remove nullable properties from AsmDiffTests projects.

### DIFF
--- a/src/AsmDiffTests/After/After.csproj
+++ b/src/AsmDiffTests/After/After.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/AsmDiffTests/Before/Before.csproj
+++ b/src/AsmDiffTests/Before/Before.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Minor change. The base Directory.Build.props already specifies it.